### PR TITLE
switch args for select method

### DIFF
--- a/code/js/content.js
+++ b/code/js/content.js
@@ -111,7 +111,7 @@ var App = new Vue({
                 value   = $(this).val();
             self.steps.push({
                 'method': 'select',
-                'args': [value, name]
+                'args': [name, value]
             });
           }
         });


### PR DESCRIPTION
Thanks for this extension, I've been enjoying using it. 
The arguments passed to the `select` method here are backwards, which has been throwing errors on my end, so I've switched them. (Oddly, the arguments for the other methods in this file also seem backwards, yet the generated code for the others (for example, `type`) is OK.)